### PR TITLE
修复在 .NET Standard 2.0 不支持 ValueTask 找不到返回值

### DIFF
--- a/AsyncWorkerCollection/AsyncQueue.cs
+++ b/AsyncWorkerCollection/AsyncQueue.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-#if NETFRAMEWORK
+#if !NETCOREAPP
 using ValueTask = System.Threading.Tasks.Task;
 #endif
 

--- a/AsyncWorkerCollection/DoubleBuffer_/DoubleBufferTask.cs
+++ b/AsyncWorkerCollection/DoubleBuffer_/DoubleBufferTask.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-#if NETFRAMEWORK
+#if !NETCOREAPP
 using ValueTask = System.Threading.Tasks.Task;
 #endif
 

--- a/AsyncWorkerCollection/IAsyncDisposable.cs
+++ b/AsyncWorkerCollection/IAsyncDisposable.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-#if NETFRAMEWORK
+#if !NETCOREAPP
 using ValueTask = System.Threading.Tasks.Task;
 #endif
 

--- a/AsyncWorkerCollection/LimitedRunningCountTask.cs
+++ b/AsyncWorkerCollection/LimitedRunningCountTask.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-#if NETFRAMEWORK
+#if !NETCOREAPP
 using ValueTask = System.Threading.Tasks.Task;
 #endif
 


### PR DESCRIPTION
根据 https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.valuetask-1?view=netcore-3.1&viewFallbackFrom=netstandard-2.0&WT.mc_id=DX-MVP-5003606 的文档

是最低版本是 .NET Standard 2.1 才可以支持