### PR TITLE
修复还有数据进入队列之后没有被消费，调用销毁时抛出异常

### DIFF
--- a/AsyncWorkerCollection/AsyncQueue.cs
+++ b/AsyncWorkerCollection/AsyncQueue.cs
@@ -150,8 +150,11 @@ namespace dotnetCampus.Threading
             // 此时将会在 DequeueAsync 进入 TryDequeue 方法，也许此时依然有开发者在 _queue.Clear() 之后插入元素，但是没关系，我只是需要保证调用 Dispose 之后会让 DequeueAsync 方法返回而已
             _isDisposed = true;
             _queue.Clear();
-            // 释放 DequeueAsync 方法，释放次数为 DequeueAsync 在调用的次数
-            _semaphoreSlim.Release(_dequeueAsyncEnterCount);
+            if (_dequeueAsyncEnterCount > 0)
+            {
+                // 释放 DequeueAsync 方法，释放次数为 DequeueAsync 在调用的次数
+                _semaphoreSlim.Release(_dequeueAsyncEnterCount);
+            }
             _semaphoreSlim.Dispose();
         }
 

--- a/AsyncWorkerCollection/AsyncQueue.cs
+++ b/AsyncWorkerCollection/AsyncQueue.cs
@@ -78,27 +78,40 @@ namespace dotnetCampus.Threading
         /// <returns>可以异步等待的队列返回的元素。</returns>
         public async Task<T> DequeueAsync(CancellationToken cancellationToken = default)
         {
-            while (!_isDisposed)
+            Interlocked.Increment(ref _dequeueAsyncEnterCount);
+            try
             {
-                await _semaphoreSlim.WaitAsync(cancellationToken).ConfigureAwait(false);
+                while (!_isDisposed)
+                {
+                    await _semaphoreSlim.WaitAsync(cancellationToken).ConfigureAwait(false);
 
-                if (_queue.TryDequeue(out var item))
-                {
-                    return item;
-                }
-                else
-                {
-                    // 当前没有任务
-                    lock (_queue)
+                    if (_queue.TryDequeue(out var item))
                     {
-                        // 事件不是线程安全，因为存在事件的加等
-                        CurrentFinished?.Invoke(this, EventArgs.Empty);
+                        return item;
+                    }
+                    else
+                    {
+                        // 当前没有任务
+                        lock (_queue)
+                        {
+                            // 事件不是线程安全，因为存在事件的加等
+                            CurrentFinished?.Invoke(this, EventArgs.Empty);
+                        }
                     }
                 }
-            }
 
-            return default!;
+                return default!;
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _dequeueAsyncEnterCount);
+            }
         }
+
+        /// <summary>
+        /// 当前进入 <see cref="DequeueAsync"/> 还没被释放的次数
+        /// </summary>
+        private int _dequeueAsyncEnterCount;
 
         /// <summary>
         /// 等待当前的所有任务执行完成
@@ -130,14 +143,15 @@ namespace dotnetCampus.Threading
         /// </summary>
         public void Dispose()
         {
+            ThrowIfDisposing();
             _isDisposing = true;
 
             // 当释放的时候，将通过 _queue 的 Clear 清空内容，而通过 _semaphoreSlim 的释放让 DequeueAsync 释放锁
             // 此时将会在 DequeueAsync 进入 TryDequeue 方法，也许此时依然有开发者在 _queue.Clear() 之后插入元素，但是没关系，我只是需要保证调用 Dispose 之后会让 DequeueAsync 方法返回而已
             _isDisposed = true;
             _queue.Clear();
-            // 释放 DequeueAsync 方法
-            _semaphoreSlim.Release(int.MaxValue);
+            // 释放 DequeueAsync 方法，释放次数为 DequeueAsync 在调用的次数
+            _semaphoreSlim.Release(_dequeueAsyncEnterCount);
             _semaphoreSlim.Dispose();
         }
 
@@ -149,6 +163,7 @@ namespace dotnetCampus.Threading
         /// <returns></returns>
         public async ValueTask DisposeAsync()
         {
+            ThrowIfDisposing();
             _isDisposing = true;
             await WaitForCurrentFinished();
 

--- a/test/AsyncWorkerCollection.Tests/AsyncQueueTest.cs
+++ b/test/AsyncWorkerCollection.Tests/AsyncQueueTest.cs
@@ -11,7 +11,7 @@ namespace AsyncWorkerCollection.Tests
         [ContractTestCase]
         public void DisposeTest()
         {
-            "在进行销毁之前，存在元素没有出队，可以成功销毁".Test(() =>
+            "在 AsyncQueue 进行销毁之前，存在元素没有出队，调用销毁时可以成功销毁".Test(() =>
             {
                 // Arrange
                 var asyncQueue = new AsyncQueue<int>();

--- a/test/AsyncWorkerCollection.Tests/AsyncQueueTest.cs
+++ b/test/AsyncWorkerCollection.Tests/AsyncQueueTest.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using dotnetCampus.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MSTest.Extensions.Contracts;
+
+namespace AsyncWorkerCollection.Tests
+{
+    [TestClass]
+    public class AsyncQueueTest
+    {
+        [ContractTestCase]
+        public void DisposeTest()
+        {
+            "在进行销毁之前，存在元素没有出队，可以成功销毁".Test(() =>
+            {
+                // Arrange
+                var asyncQueue = new AsyncQueue<int>();
+                asyncQueue.Enqueue(0);
+                asyncQueue.Enqueue(0);
+
+                // Action
+                asyncQueue.Dispose();
+
+                // Assert
+                Assert.AreEqual(0, asyncQueue.Count);
+            });
+        }
+    }
+}


### PR DESCRIPTION
假定依然有数据没有被消费，此时调用销毁的方法里面释放了 int.MaxValue 次将会超过信号量能支持的最大次数

解决方法就是只释放当前在 DequeueAsync 等待的次数

