### PR TITLE
修复在非 NET45 下构建失败

### DIFF
--- a/AsyncWorkerCollection/IAsyncDisposable.cs
+++ b/AsyncWorkerCollection/IAsyncDisposable.cs
@@ -11,7 +11,7 @@ using ValueTask = System.Threading.Tasks.Task;
 namespace dotnetCampus.Threading
 {
     // 尽管设置 csproj 不引用这个文件，但是在源代码引用的时候，依然会添加这个文件，因此需要判断当前如果是 net45 就忽略这个代码
-#if NET45 || NETSTANDARD2_0
+#if NETFRAMEWORK || NETSTANDARD2_0
     // 这个接口在 .NET Framework 4.5 没有
     interface IAsyncDisposable
     {


### PR DESCRIPTION
如使用 .NET 4.5.1 版本，原先的 #if NET45 就没有进入