### PR TITLE
修复 Finish 多次调用而失败的问题

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,8 +6,10 @@ insert_final_newline = true
 tab_width = 4
 trim_trailing_whitespace = true
 
-[*.xml]
+[*.{xml,csproj,vbproj,props,targets}]
+indent_size =2
 indent_style = space
+tab_width =2
 
 [*.{cs,vb}]
 dotnet_sort_system_directives_first = true

--- a/AsyncWorkerCollection/DoubleBuffer_/DoubleBufferTask.cs
+++ b/AsyncWorkerCollection/DoubleBuffer_/DoubleBufferTask.cs
@@ -97,8 +97,14 @@ namespace dotnetCampus.Threading
                     return;
                 }
 
-                Finished += (sender, args) => FinishTask.SetResult(true);
+                Finished += OnFinished;
             }
+        }
+
+        private void OnFinished(object sender, EventArgs args)
+        {
+            Finished -= OnFinished;
+            FinishTask.SetResult(true);
         }
 
         /// <summary>

--- a/AsyncWorkerCollection/DoubleBuffer_/DoubleBufferTask.cs
+++ b/AsyncWorkerCollection/DoubleBuffer_/DoubleBufferTask.cs
@@ -83,6 +83,14 @@ namespace dotnetCampus.Threading
         {
             lock (Locker)
             {
+                if (_isSetFinish)
+                {
+                    // 重复多次调用 Finish 方法，第二次调用将无效
+                    return;
+                }
+
+                _isSetFinish = true;
+
                 if (!_isDoing)
                 {
                     FinishTask.SetResult(true);
@@ -103,6 +111,11 @@ namespace dotnetCampus.Threading
         }
 
         private TaskCompletionSource<bool> FinishTask { get; } = new TaskCompletionSource<bool>();
+
+        /// <summary>
+        /// 是否调用了 <see cref="Finish"/> 方法，因为此方法不适合多次重复调用
+        /// </summary>
+        private bool _isSetFinish;
 
         private volatile bool _isDoing;
 

--- a/test/AsyncWorkerCollection.Tests/DoubleBufferTaskTest.cs
+++ b/test/AsyncWorkerCollection.Tests/DoubleBufferTaskTest.cs
@@ -14,6 +14,30 @@ namespace AsyncWorkerCollection.Tests
         [ContractTestCase]
         public void Finish()
         {
+            "在设置 DoubleBufferTask 的 Finish 方法之后，调用 AddTask 加入任务将会抛出异常".Test(() =>
+            {
+                var mock = new Mock<IFoo>();
+                mock.Setup(foo => foo.Foo());
+                var asyncManualResetEvent = new AsyncManualResetEvent(false);
+
+                var doubleBufferTask = new DoubleBufferTask<IFoo>(async list =>
+                {
+                    await asyncManualResetEvent.WaitOneAsync();
+
+                    foreach (var foo in list)
+                    {
+                        foo.Foo();
+                    }
+                });
+
+                doubleBufferTask.Finish();
+
+                Assert.ThrowsException<InvalidOperationException>(() =>
+                {
+                    doubleBufferTask.AddTask(mock.Object);
+                });
+            });
+
             "重复多次设置 DoubleBufferTask 的 Finish 方法，不会出现任何异常".Test(() =>
             {
                 var mock = new Mock<IFoo>();


### PR DESCRIPTION
原本的设计是 Finish  只能被调用一次，但是后续发现实际项目业务端被疯狂调用，按照 [晓嗔戈](https://github.com/Firito) 的说法是，一个月有 200w 次重复调用，对应内部代号为 EN-26694 的问题