### PR TITLE
由于 async void 是线程顶层，抛出异常将会炸掉进程

### DIFF
--- a/AsyncWorkerCollection/AsyncTaskQueue_/AsyncTaskQueue.cs
+++ b/AsyncWorkerCollection/AsyncTaskQueue_/AsyncTaskQueue.cs
@@ -21,7 +21,7 @@ namespace dotnetCampus.Threading
         public AsyncTaskQueue()
         {
             _autoResetEvent = new AsyncAutoResetEvent(false);
-            InternalRunning();
+            _ = InternalRunning();
         }
 
         #region 执行
@@ -113,7 +113,7 @@ namespace dotnetCampus.Threading
 
         #region 内部运行
 
-        private async void InternalRunning()
+        private async Task InternalRunning()
         {
             while (!_isDisposing)
             {

--- a/AsyncWorkerCollection/DoubleBuffer_/DoubleBufferTask.cs
+++ b/AsyncWorkerCollection/DoubleBuffer_/DoubleBufferTask.cs
@@ -54,10 +54,10 @@ namespace dotnetCampus.Threading
             }
 
             DoubleBuffer.Add(t);
-            DoInner();
+            _ = DoInner();
         }
 
-        private async void DoInner()
+        private async Task DoInner()
         {
             // ReSharper disable once InconsistentlySynchronizedField
             if (_isDoing) return;

--- a/AsyncWorkerCollection/LimitedRunningCountTask.cs
+++ b/AsyncWorkerCollection/LimitedRunningCountTask.cs
@@ -68,7 +68,7 @@ namespace dotnetCampus.Threading
                 RunningBreakTask?.TrySetResult(true);
             }
 
-            RunningInner();
+            _ = RunningInner();
         }
 
         /// <summary>
@@ -145,7 +145,7 @@ namespace dotnetCampus.Threading
 
         private TaskCompletionSource<bool>? _waitForFreeTask;
 
-        private async void RunningInner()
+        private async Task RunningInner()
         {
             // ReSharper disable once InconsistentlySynchronizedField
             if (_isRunning)

--- a/AsyncWorkerCollection/Reentrancy/KeepLastReentrancyTask.cs
+++ b/AsyncWorkerCollection/Reentrancy/KeepLastReentrancyTask.cs
@@ -76,14 +76,14 @@ namespace dotnetCampus.Threading.Reentrancy
         {
             var wrapper = new TaskWrapper(() => RunCore(arg), _configureAwait);
             _queue.Enqueue(wrapper);
-            Run();
+            _ = Run();
             return wrapper.AsTask();
         }
 
         /// <summary>
         /// 以KeepLast策略执行重入任务。此方法确保线程安全。
         /// </summary>
-        private async void Run()
+        private async Task Run()
         {
             var isRunning = Interlocked.CompareExchange(ref _isRunning, 1, 0);
             if (isRunning is 1)

--- a/AsyncWorkerCollection/Reentrancy/QueueReentrancyTask.cs
+++ b/AsyncWorkerCollection/Reentrancy/QueueReentrancyTask.cs
@@ -70,14 +70,14 @@ namespace dotnetCampus.Threading.Reentrancy
         {
             var wrapper = new TaskWrapper(() => RunCore(arg));
             _queue.Enqueue(wrapper);
-            Run();
+            _ = Run();
             return wrapper.AsTask();
         }
 
         /// <summary>
         /// 以队列策略执行重入任务。此方法确保线程安全。
         /// </summary>
-        private async void Run()
+        private async Task Run()
         {
             var isRunning = Interlocked.CompareExchange(ref _isRunning, 1, 0);
             if (isRunning is 1)


### PR DESCRIPTION
全部修改为 Task 返回，如此在抛出异常时，可以被全局收到

sentry 31889